### PR TITLE
[안재관] step1: 회원 관리 기능 구현 완료

### DIFF
--- a/src/main/java/com/example/springmvc/config/WebConfig.java
+++ b/src/main/java/com/example/springmvc/config/WebConfig.java
@@ -1,0 +1,23 @@
+package com.example.springmvc.config;
+
+import com.example.springmvc.interceptor.JwtAuthInterceptor;
+import org.springframework.beans.factory.annotation.Configurable;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configurable
+public class WebConfig implements WebMvcConfigurer {
+    private final JwtAuthInterceptor jwtAuthInterceptor;
+
+    public WebConfig(JwtAuthInterceptor jwtAuthInterceptor) {
+        this.jwtAuthInterceptor = jwtAuthInterceptor;
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(jwtAuthInterceptor)
+                .addPathPatterns("/api/posts/**", "/api/images/**") // 인증 필요한 URL
+                .excludePathPatterns("/api/posts", "/api/posts/**") // GET 요청 허용용 예외 (선택 사항)
+                .excludePathPatterns("/api/users/register", "/api/users/login"); // 로그인/회원가입은 인증 제외
+    }
+}

--- a/src/main/java/com/example/springmvc/controller/UserController.java
+++ b/src/main/java/com/example/springmvc/controller/UserController.java
@@ -1,0 +1,47 @@
+package com.example.springmvc.controller;
+
+import com.example.springmvc.dto.UserLoginRequest;
+import com.example.springmvc.dto.UserRegisterRequest;
+import com.example.springmvc.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping("api/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    // 회원가입 요청 시 실행
+    @PostMapping("/register")
+    public ResponseEntity<Map<String, Object>> register(@Valid @RequestBody UserRegisterRequest request) {
+        userService.register(request);
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("success", true);
+        response.put("message", "회원 가입이 완료되었습니다.");
+
+        return ResponseEntity.ok(response);
+    }
+
+    // 로그인 요청 시 실행(토근 포함한 응답 반환)
+    @PostMapping("/login")
+    public ResponseEntity<Map<String, Object>> login(@Valid @RequestBody UserLoginRequest request) {
+        String token = userService.login(request);
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("success", true);
+        response.put("token", token);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/example/springmvc/domain/User.java
+++ b/src/main/java/com/example/springmvc/domain/User.java
@@ -1,0 +1,14 @@
+package com.example.springmvc.domain;
+
+import lombok.Data;
+
+import java.time.Instant;
+
+@Data
+public class User {
+    private String id;
+    private String password;
+    private String email;
+    private String nickname;
+    private Instant createdAt;
+}

--- a/src/main/java/com/example/springmvc/dto/UserLoginRequest.java
+++ b/src/main/java/com/example/springmvc/dto/UserLoginRequest.java
@@ -1,0 +1,15 @@
+package com.example.springmvc.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+// 로그인 유효성 검사
+public record UserLoginRequest(
+        @NotBlank
+        @Size(min = 6, max = 30)
+        String id,
+
+        @NotBlank
+        @Size(min = 12, max = 50)
+        String password
+) {}

--- a/src/main/java/com/example/springmvc/dto/UserRegisterRequest.java
+++ b/src/main/java/com/example/springmvc/dto/UserRegisterRequest.java
@@ -1,0 +1,30 @@
+package com.example.springmvc.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+// 회원가입 유효성 검사
+public record UserRegisterRequest(
+        @NotBlank
+        @Size(min = 6, max = 30)
+        String id,
+
+        @NotBlank
+        @Size(min = 12, max = 50)
+        @Pattern(
+                regexp = "^(?=(.*[a-zA-Z]){2,})(?=(.*\\d){2,})(?=(.*[!@#$%^&*]){2,}).{12,50}$",
+                message = "비밀번호는 영문, 숫자, 특수문자(!@#$%^&*)를 각각 2자 이상 포함해야 합니다."
+        )
+        String password,
+
+        @NotBlank
+        @Email
+        @Size(max = 100)
+        String email,
+
+        @NotBlank
+        @Size(min = 3, max = 50)
+        String nickname
+) {}

--- a/src/main/java/com/example/springmvc/interceptor/JwtAuthInterceptor.java
+++ b/src/main/java/com/example/springmvc/interceptor/JwtAuthInterceptor.java
@@ -1,0 +1,61 @@
+package com.example.springmvc.interceptor;
+
+import com.example.springmvc.service.UserService;
+import com.example.springmvc.util.JwtUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+public class JwtAuthInterceptor implements HandlerInterceptor {
+
+    private final JwtUtil jwtUtil;
+    private final UserService userService;
+
+    public JwtAuthInterceptor(JwtUtil jwtUtil, UserService userService) {
+        this.jwtUtil = jwtUtil;
+        this.userService = userService;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        final String authorizationHeader = request.getHeader("Authorization");
+
+        String userId = null;
+        String jwt = null;
+
+        if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+            jwt = authorizationHeader.substring(7);
+            try {
+                userId = jwtUtil.extractUserId(jwt);
+            } catch (Exception e) {
+                response.setStatus(HttpStatus.UNAUTHORIZED.value());
+                response.getWriter().write("{\"error\":\"Invalid token\"}");
+                return false;
+            }
+        } else {
+            response.setStatus(HttpStatus.UNAUTHORIZED.value());
+            response.getWriter().write("{\"error\":\"Missing or invalid Authorization header\"}");
+            return false;
+        }
+
+        if (userId != null && jwtUtil.validateToken(jwt)) {
+            // 사용자 존재 여부 확인
+            if (!userService.existsById(userId)) {
+                response.setStatus(HttpStatus.UNAUTHORIZED.value());
+                response.getWriter().write("{\"error\":\"User not found\"}");
+                return false;
+            }
+
+            // 요청 속성에 사용자 ID 저장 (컨트롤러에서 접근 가능)
+            request.setAttribute("userId", userId);
+            return true;
+        }
+
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.getWriter().write("{\"error\":\"Invalid token\"}");
+        return false;
+    }
+}

--- a/src/main/java/com/example/springmvc/repository/MemeoryUserRepository.java
+++ b/src/main/java/com/example/springmvc/repository/MemeoryUserRepository.java
@@ -1,0 +1,28 @@
+package com.example.springmvc.repository;
+
+import com.example.springmvc.domain.User;
+import org.springframework.stereotype.Repository;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Repository
+public class MemeoryUserRepository implements UserRepository {
+    private final Map<String, User> storage = new HashMap<>();
+
+    @Override
+    public void save(User user) {
+        storage.put(user.getId(), user);
+    }
+
+    @Override
+    public Optional<User> findById(String id) {
+        return Optional.ofNullable(storage.get(id));
+    }
+
+    @Override
+    public boolean existsById(String id) {
+        return storage.containsKey(id);
+    }
+}

--- a/src/main/java/com/example/springmvc/repository/UserRepository.java
+++ b/src/main/java/com/example/springmvc/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.example.springmvc.repository;
+
+import com.example.springmvc.domain.User;
+
+import java.util.Optional;
+
+public interface UserRepository {
+    void save(User user);
+    Optional<User> findById(String id);
+    boolean existsById(String id);
+}

--- a/src/main/java/com/example/springmvc/service/UserService.java
+++ b/src/main/java/com/example/springmvc/service/UserService.java
@@ -1,0 +1,10 @@
+package com.example.springmvc.service;
+
+import com.example.springmvc.dto.UserLoginRequest;
+import com.example.springmvc.dto.UserRegisterRequest;
+
+public interface UserService {
+    void register(UserRegisterRequest request);
+    String login(UserLoginRequest request);
+    boolean existsById(String id);
+}

--- a/src/main/java/com/example/springmvc/service/UserServiceImpl.java
+++ b/src/main/java/com/example/springmvc/service/UserServiceImpl.java
@@ -1,0 +1,54 @@
+package com.example.springmvc.service;
+
+import com.example.springmvc.domain.User;
+import com.example.springmvc.dto.UserLoginRequest;
+import com.example.springmvc.dto.UserRegisterRequest;
+import com.example.springmvc.repository.UserRepository;
+import com.example.springmvc.util.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.mindrot.jbcrypt.BCrypt;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+    private final UserRepository userRepository;
+    private final JwtUtil jwtUtil;
+
+    @Override
+    public void register(UserRegisterRequest request) {
+        if (userRepository.existsById(request.id())) {
+            throw new IllegalArgumentException("이미 존재하는 ID입니다.");
+        }
+
+        // 비밀번호 암호화
+        String hashedPassword = BCrypt.hashpw(request.password(), BCrypt.gensalt());
+
+        User user = new User();
+        user.setId(request.id());
+        user.setPassword(hashedPassword);
+        user.setEmail(request.email());
+        user.setNickname(request.nickname());
+        user.setCreatedAt(Instant.now());
+        userRepository.save(user);
+    }
+
+    @Override
+    public String login(UserLoginRequest request) {
+        User user = userRepository.findById(request.id())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 ID 입니다."));
+
+        if(!BCrypt.checkpw(request.password(), user.getPassword())){
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+        }
+
+        return jwtUtil.generateToken(user.getId());
+    }
+
+    @Override
+    public boolean existsById(String id) {
+        return userRepository.existsById(id);
+    }
+}

--- a/src/main/java/com/example/springmvc/util/JwtUtil.java
+++ b/src/main/java/com/example/springmvc/util/JwtUtil.java
@@ -1,0 +1,74 @@
+package com.example.springmvc.util;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+@Component
+public class JwtUtil {
+
+    // 실제 서비스에서는 외부 설정으로 관리해야 하는 비밀키
+    private final Key key = Keys.secretKeyFor(SignatureAlgorithm.HS256);
+
+    // 토큰에서 사용자 ID 추출
+    public String extractUserId(String token) {
+        return extractClaim(token, Claims::getSubject);
+    }
+
+    // 모든 클레임 추출
+    public Claims extractAllClaims(String token) {
+        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+    }
+
+    // 특정 클레임 추출
+    public <T> T extractClaim(String token, Function<Claims, T> claimsResolver) {
+        final Claims claims = extractAllClaims(token);
+        return claimsResolver.apply(claims);
+    }
+
+    // 토큰 생성
+    public String generateToken(String userId) {
+        Map<String, Object> claims = new HashMap<>();
+        return createToken(claims, userId);
+    }
+
+    // 토큰 생성 (내부 메서드)
+    private String createToken(Map<String, Object> claims, String subject) {
+        return Jwts.builder()
+                .setClaims(claims)
+                .setSubject(subject)
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                // 무한 유효기간 대신 매우 긴 유효기간 설정 (예: 100년)
+                .setExpiration(new Date(System.currentTimeMillis() + 1000L * 60 * 60 * 24 * 365 * 100))
+                .signWith(key)
+                .compact();
+    }
+
+    // 토큰 유효성 검증
+    public Boolean validateToken(String token) {
+        try {
+            return !isTokenExpired(token);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    // 토큰 만료 확인
+    private Boolean isTokenExpired(String token) {
+        final Date expiration = extractExpiration(token);
+        return expiration.before(new Date());
+    }
+
+    // 만료일 추출
+    private Date extractExpiration(String token) {
+        return extractClaim(token, Claims::getExpiration);
+    }
+}


### PR DESCRIPTION
### 1단계: 회원 관리 기능

- [x]  **회원 가입 기능**
    - ID, 비밀번호(암호화), 이메일, 닉네임 저장
    - 각 필드 유효성 검사:
        - ID: 6-30글자
        - 비밀번호: 12-50글자, 영문/숫자/특수문자(`!@#$%^&*`) 각 2글자 이상 포함
        - 이메일: 이메일 형식, 100글자 이하
        - 닉네임: 3~50글자
    - ID 중복 검사

- [x] **로그인 기능**
    - JWT 액세스 토큰 발급 (유효기간 무한)
    - 토큰은 메모리에만 저장(영속화 X)
    - 인증이 필요한 API 호출 시 HTTP 헤더의 `Authorization: Bearer {token}` 형식으로 전송

### 스크린샷 
<img width="1431" alt="1" src="https://github.com/user-attachments/assets/4a760f41-7677-458d-9f8f-c6aa6fa58480" />
<img width="1431" alt="2" src="https://github.com/user-attachments/assets/fbda4cac-452e-431d-ba08-3e8c86bffbdd" />
